### PR TITLE
Added the "## Using filters on Windows" paragraph for international users

### DIFF
--- a/_posts/articles/2016-03-19-Filters.md
+++ b/_posts/articles/2016-03-19-Filters.md
@@ -25,7 +25,28 @@ Per default, all files and folders will be backed up. That means, if no rule mat
 If you want to use file globbing to specify rules, `?` and `*` are allowed placeholders. `?` matches any single character. `*` specifies none or multiple characters. Rules can also be specified as regular expression. In this case put the regular expression (using .NET syntax) into hard brackets `[]`. Folder names always end with a slash `/` on Linux or Mac and a backslash `\` on Windows. For instance, `log` is a file, `log/` is a folder. In the UI a rule to include is started with a `+`, a rule to exclude is started with a `-`. Using the command-line there are specific settings to specify include or exclude rules. These are `--include` and `--exclude`. Using the command-line various rules can be specified using `--include` or `--exclude` repeatedly.
 
 ## Settings
+
 Besides filter rules there are settings that can exclude specific files by their attributes. Those settings are `--skip-files-larger-than` and `--exclude-files-attributes`. The latter is able to exclude files that have any of the following attributes: ReadOnly, Hidden, System, Directory, Archive, Device, Normal, Temporary. Those settings are applied to all files of the backup.
+
+## Using filters on Windows
+
+Paths in Windows require the backslash `\` separator. The %HOME% keyword in the filter path is not supported. 
+
+Duplicati does not support the symbolic links created by Windows in the User's home directory for non-English versions of the OS. To filter the relative directories, use their path addresses: 
+
+ * \Desktop
+ * \Pictures
+ * \Music
+ * \Videos
+ * \Documents
+ * \Contacts
+ * \Downloads
+ 
+The root directory for users is `\Users` regardless of the language of the OS. For example, to exclude from the backup the Movies and Music folders of the user 'MickeyMouse', add the following filters in teh Duplicati Interface:
+ 
+  * Directory filter: *\Users\MickeyMouse\Music
+  * Directory filter: *\Users\MickeyMouse\Videos
+
 
 ## Common use cases
 

--- a/_posts/articles/2016-03-19-Filters.md
+++ b/_posts/articles/2016-03-19-Filters.md
@@ -32,7 +32,7 @@ Besides filter rules there are settings that can exclude specific files by their
 
 Paths in Windows require the backslash `\` separator. The %HOME% keyword in the filter path is not supported. 
 
-Duplicati does not support the symbolic links created by Windows in the User's home directory for non-English versions of the OS. To filter the relative directories, use their path addresses: 
+Duplicati does not support the symbolic links created by Windows in the User's home directory for non-English versions of the OS. To filter the relative folders, use their path addresses: 
 
  * \Desktop
  * \Pictures
@@ -44,8 +44,8 @@ Duplicati does not support the symbolic links created by Windows in the User's h
  
 The root directory for users is `\Users` regardless of the language of the OS. For example, to exclude from the backup the Movies and Music folders of the user 'MickeyMouse', add the following filters in teh Duplicati Interface:
  
-  * Directory filter: *\Users\MickeyMouse\Music
-  * Directory filter: *\Users\MickeyMouse\Videos
+  * Exclude folder: *\Users\MickeyMouse\Music
+  * Exclude folder: *\Users\MickeyMouse\Videos
 
 
 ## Common use cases


### PR DESCRIPTION
It addresses some issues found on the Windows version of Duplicati.

I found those rules by trial and error, after failing many times in setting my filters for a catch-all job. I guess the info can be of use to other people. Among others things:

- the  %HOME% alias is not parsed in the filters
- the international versions of Windows have symbolic links of common directories in the home folder so that the user can access them in their native language (for example, in my Italian version of Windoes 10, I have "Documenti" instead of Documents, "Musica" instead of "Music"... and so on). Duplicati does not recognize them
- I added some examples on how to filter out those directories (or directories in general)
